### PR TITLE
PR for Social Nav Links 

### DIFF
--- a/src/aura/uswdsSocialMediaNavMenu/uswdsSocialMediaNavMenu.cmp
+++ b/src/aura/uswdsSocialMediaNavMenu/uswdsSocialMediaNavMenu.cmp
@@ -26,9 +26,8 @@
         start="{! v.startNumber }"
       >
         <div class="grid-col-auto">
-          <a class="usa-social-link" data-menu-item-id="{!item.id}">
-            <c:fontAwesomeIcon properName="{!item.label}" />
-            <span>{!item.label}</span>
+          <a class="usa-social-link" data-menu-item-id="{!item.id}" href="" onclick="{!c.onClick}" data-row-index="{!item.id}">
+              <c:fontAwesomeIcon properName="{!item.label}" />
           </a>
         </div>
       </aura:iteration>

--- a/src/aura/uswdsSocialMediaNavMenu/uswdsSocialMediaNavMenu.cmp
+++ b/src/aura/uswdsSocialMediaNavMenu/uswdsSocialMediaNavMenu.cmp
@@ -26,8 +26,14 @@
         start="{! v.startNumber }"
       >
         <div class="grid-col-auto">
-          <a class="usa-social-link" data-menu-item-id="{!item.id}" href="" onclick="{!c.onClick}" data-row-index="{!item.id}">
-              <c:fontAwesomeIcon properName="{!item.label}" />
+          <a
+            class="usa-social-link"
+            data-menu-item-id="{!item.id}"
+            href=""
+            onclick="{!c.onClick}"
+            data-row-index="{!item.id}"
+          >
+            <c:fontAwesomeIcon properName="{!item.label}" />
           </a>
         </div>
       </aura:iteration>

--- a/src/aura/uswdsSocialMediaNavMenu/uswdsSocialMediaNavMenuController.js
+++ b/src/aura/uswdsSocialMediaNavMenu/uswdsSocialMediaNavMenuController.js
@@ -1,7 +1,7 @@
 ({
   doInit: function (cmp, event, helper) {},
   onClick: function (component, event, helper) {
-    var id = event.target.dataset.menuItemId;
+    var id = event.currentTarget.dataset.rowIndex;
     if (id) {
       component.getSuper().navigate(id);
     }


### PR DESCRIPTION
**Summary**

After creating a social media nav menu, clicking one of the font awesome icons does not result in the desired navigation result. Instead, nothing happens. The PR fixes the issue 

This PR fixes/implements the following **bugs/features**

- [x ] Bug 1

Explain the **motivation** for making this change. What existing problem does the pull request solve?
When clicking on the font awesome icons on the social media nav menu would result in opening the links.

**Test plan (required)**

Deploy 1.3.0
Create new community/ change theme to current
Create new navigation menu titled 'social'
Create two nav menu items facebook, facebook.com and twitter, twitter.com. Make both links publicly accessible
Save
Publish community
Scroll down to social media nav menu in footer and click the facebook or twitter icons, should open the links.
<!-- Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

**Code formatting**

<!-- We use Prettier and so should you. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes #50
