### PR TITLE
Issue 66

### DIFF
--- a/src/aura/uswdsTheme/uswdsTheme.cmp
+++ b/src/aura/uswdsTheme/uswdsTheme.cmp
@@ -85,7 +85,6 @@
   <!-- END attributes -->
   <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
 
-
   <a class="usa-skipnav" href="#mainContent">Skip to Main Content</a>
   <div class="slds-grid">
     <div class="slds-col slds-size_1-of-1">
@@ -99,11 +98,14 @@
             <em class="usa-logo__text">
               <div class="slds-media slds-media_center">
                 <div class="slds-media__figure" aura:id="media-figure">
-                  <span class="slds-avatar slds-avatar_large logoContainer" aura:id="logoContainer">
+                  <span
+                    class="slds-avatar slds-avatar_large logoContainer"
+                    aura:id="logoContainer"
+                  >
                     <a href="{!v.homePath}" title="Home" aria-label="Home">
                       <img
                         class="logoContainer"
-                        alt="{!v.siteName}"
+                        alt="{!v.siteName + 'logo'}"
                         src=""
                         title="Home"
                       />
@@ -111,12 +113,12 @@
                   </span>
                 </div>
                 <aura:if isTrue="{!v.logoType == 'Square'}">
-                <div class="slds-media__body">
-                  <a href="{!v.homePath}" title="Home" aria-label="Home">
-                    {!v.siteName}
-                  </a>
-                </div>
-              </aura:if>
+                  <div class="slds-media__body">
+                    <a href="{!v.homePath}" title="Home" aria-label="Home">
+                      {!v.siteName}
+                    </a>
+                  </div>
+                </aura:if>
               </div>
             </em>
           </div>

--- a/src/aura/uswdsTheme/uswdsTheme.cmp
+++ b/src/aura/uswdsTheme/uswdsTheme.cmp
@@ -82,6 +82,8 @@
   <!-- END attributes -->
   <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
 
+  <aura:attribute name="logotype" type="String" default="wide" />
+
   <a class="usa-skipnav" href="#mainContent">Skip to Main Content</a>
   <div class="slds-grid">
     <div class="slds-col slds-size_1-of-1">
@@ -106,11 +108,13 @@
                     </a>
                   </span>
                 </div>
+                <aura:if isTrue="{!v.logotype == 'narrow'}">
                 <div class="slds-media__body">
                   <a href="{!v.homePath}" title="Home" aria-label="Home">
                     {!v.siteName}
                   </a>
                 </div>
+              </aura:if>
               </div>
             </em>
           </div>

--- a/src/aura/uswdsTheme/uswdsTheme.cmp
+++ b/src/aura/uswdsTheme/uswdsTheme.cmp
@@ -9,6 +9,9 @@
   <ltng:require scripts="{!$Resource.uswds_2_x+'/js/uswds.min.js'}" />
 
   <!-- component drop zones and toggles -->
+  <!-- header image and text options -->
+  <aura:attribute name="logoType" type="String" default="Square" />
+
   <!-- navBar options -->
   <aura:attribute name="navBar" type="Aura.Component[]" required="false" />
   <aura:attribute name="customNavToggle" type="String" default="Off" />
@@ -80,7 +83,6 @@
   <!-- END attributes -->
   <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
 
-  <aura:attribute name="logotype" type="String" default="wide" />
 
   <a class="usa-skipnav" href="#mainContent">Skip to Main Content</a>
   <div class="slds-grid">
@@ -94,8 +96,8 @@
           <div class="usa-logo" id="extended-logo">
             <em class="usa-logo__text">
               <div class="slds-media slds-media_center">
-                <div class="slds-media__figure">
-                  <span class="slds-avatar slds-avatar_large logoContainer">
+                <div class="slds-media__figure" aura:id="media-figure">
+                  <span class="slds-avatar slds-avatar_large logoContainer" aura:id="logoContainer">
                     <a href="{!v.homePath}" title="Home" aria-label="Home">
                       <img
                         class="logoContainer"
@@ -106,7 +108,7 @@
                     </a>
                   </span>
                 </div>
-                <aura:if isTrue="{!v.logotype == 'narrow'}">
+                <aura:if isTrue="{!v.logoType == 'Square'}">
                 <div class="slds-media__body">
                   <a href="{!v.homePath}" title="Home" aria-label="Home">
                     {!v.siteName}

--- a/src/aura/uswdsTheme/uswdsTheme.cmp
+++ b/src/aura/uswdsTheme/uswdsTheme.cmp
@@ -80,6 +80,8 @@
   <!-- END attributes -->
   <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
 
+  <aura:attribute name="logotype" type="String" default="wide" />
+
   <a class="usa-skipnav" href="#mainContent">Skip to Main Content</a>
   <div class="slds-grid">
     <div class="slds-col slds-size_1-of-1">
@@ -104,11 +106,13 @@
                     </a>
                   </span>
                 </div>
+                <aura:if isTrue="{!v.logotype == 'narrow'}">
                 <div class="slds-media__body">
                   <a href="{!v.homePath}" title="Home" aria-label="Home">
                     {!v.siteName}
                   </a>
                 </div>
+              </aura:if>
               </div>
             </em>
           </div>

--- a/src/aura/uswdsTheme/uswdsTheme.cmp
+++ b/src/aura/uswdsTheme/uswdsTheme.cmp
@@ -9,6 +9,9 @@
   <ltng:require scripts="{!$Resource.uswds_2_x+'/js/uswds.min.js'}" />
 
   <!-- component drop zones and toggles -->
+  <!-- header image and text options -->
+  <aura:attribute name="logoType" type="String" default="Square" />
+
   <!-- navBar options -->
   <aura:attribute name="navBar" type="Aura.Component[]" required="false" />
   <aura:attribute name="customNavToggle" type="String" default="Off" />
@@ -82,7 +85,6 @@
   <!-- END attributes -->
   <aura:handler name="init" value="{!this}" action="{!c.doInit}" />
 
-  <aura:attribute name="logotype" type="String" default="wide" />
 
   <a class="usa-skipnav" href="#mainContent">Skip to Main Content</a>
   <div class="slds-grid">
@@ -96,8 +98,8 @@
           <div class="usa-logo" id="extended-logo">
             <em class="usa-logo__text">
               <div class="slds-media slds-media_center">
-                <div class="slds-media__figure">
-                  <span class="slds-avatar slds-avatar_large logoContainer">
+                <div class="slds-media__figure" aura:id="media-figure">
+                  <span class="slds-avatar slds-avatar_large logoContainer" aura:id="logoContainer">
                     <a href="{!v.homePath}" title="Home" aria-label="Home">
                       <img
                         class="logoContainer"
@@ -108,7 +110,7 @@
                     </a>
                   </span>
                 </div>
-                <aura:if isTrue="{!v.logotype == 'narrow'}">
+                <aura:if isTrue="{!v.logoType == 'Square'}">
                 <div class="slds-media__body">
                   <a href="{!v.homePath}" title="Home" aria-label="Home">
                     {!v.siteName}

--- a/src/aura/uswdsTheme/uswdsTheme.design
+++ b/src/aura/uswdsTheme/uswdsTheme.design
@@ -172,6 +172,6 @@
     name="agencyLogo2"
     label="Second Agency Logo Asset Name"
     default=""
-    description="If choosing a 'Multi' option from Identifier Type, enter name of ContentAsset. Instructions at https://github.com/GSA/uswds-sf-lightning-community/wiki/Theme-Settings"
+    description="If choosing a 'Multi' option from Identifier Type, enter name of ContentAsset. Instructions at https://github.com/GSA/uswds-sf-lightning-community/wiki/Theme-Settings#second-agency-logo-asset-name"
   />
 </design:component>

--- a/src/aura/uswdsTheme/uswdsTheme.design
+++ b/src/aura/uswdsTheme/uswdsTheme.design
@@ -159,6 +159,6 @@
     name="agencyLogo2"
     label="Second Agency Logo Asset Name"
     default=""
-    description="If choosing a 'Multi' option from Identifier Type, enter name of ContentAsset. Instructions at https://github.com/GSA/uswds-sf-lightning-community/wiki/Theme-Settings"
+    description="If choosing a 'Multi' option from Identifier Type, enter name of ContentAsset. Instructions at https://github.com/GSA/uswds-sf-lightning-community/wiki/Theme-Settings#second-agency-logo-asset-name"
   />
 </design:component>

--- a/src/aura/uswdsTheme/uswdsTheme.design
+++ b/src/aura/uswdsTheme/uswdsTheme.design
@@ -17,6 +17,12 @@
     description="Defaults to /s but can be changed if your site uses a longer URI path such as abc.gov/myAppName/s. In which case, your home path would be /myAppName/s"
   />
   <design:attribute
+    name="logoType"
+    datasource="Square, Wide"
+    default="Square" 
+    description="Square enables space for a 1:1 ratio image in top left corner of the site along with the Website Name. Wide removes the Website Name in favor of a rectangular logo that can stretch further right in the header."
+  />
+  <design:attribute
     name="secondaryNavigationLinkSetId"
     label="Header Secondary Nav Menu Name"
     description="Allows you to add links below the search box such as 'advanced search' or others that may be relevant"

--- a/src/aura/uswdsTheme/uswdsTheme.design
+++ b/src/aura/uswdsTheme/uswdsTheme.design
@@ -18,6 +18,7 @@
   />
   <design:attribute
     name="logoType"
+    label="Logo Type"
     datasource="Square, Wide"
     default="Square"
     description="Square enables space for a 1:1 ratio image in top left corner of the site along with the Website Name. Wide removes the Website Name in favor of a rectangular logo that can stretch further right in the header."

--- a/src/aura/uswdsTheme/uswdsTheme.design
+++ b/src/aura/uswdsTheme/uswdsTheme.design
@@ -19,7 +19,7 @@
   <design:attribute
     name="logoType"
     datasource="Square, Wide"
-    default="Square" 
+    default="Square"
     description="Square enables space for a 1:1 ratio image in top left corner of the site along with the Website Name. Wide removes the Website Name in favor of a rectangular logo that can stretch further right in the header."
   />
   <design:attribute

--- a/src/aura/uswdsTheme/uswdsThemeController.js
+++ b/src/aura/uswdsTheme/uswdsThemeController.js
@@ -23,6 +23,16 @@
       $A.util.addClass(shoppingCart, "grid-offset-10");
     }
 
+    /* logo Type */
+    var logoType = cmp.get("v.logoType");
+    if (logoType == "Wide") {
+      var logoContainer = cmp.find("logoContainer");
+      $A.util.removeClass(logoContainer, "slds-avatar");
+      $A.util.removeClass(logoContainer, "slds-avatar_large");
+      var mediaFigure = cmp.find("media-figure");
+      $A.util.removeClass(mediaFigure, "slds-media__figure");
+    }
+
     /* Container Width */
     var containerWidth = cmp.get("v.containerWidth");
     var mainContent = cmp.find("mainContent");


### PR DESCRIPTION
**Summary**

This PR addresses #66 

**Test plan (required)**

- [x] deploy code. Navigate to Experience Builder > Theme Settings
- [x] select a 1:1 aspect ratio image 
![logo](https://user-images.githubusercontent.com/4053083/134791005-fdea46e0-9ac8-415e-9f4f-6196f3154aa1.png)
, upload as logo, observe alignment to left of "Website/ Application Name"
- [x] Select "Wide" from Logo Type, "Website/ Application Name" should disappear
- [x] Upload a wide image 
![wideLogo](https://user-images.githubusercontent.com/4053083/134791001-38be4fb2-8693-4df5-a6a4-829756749b38.png), set image as Company Logo
- [x] observe image occupying header space
- [x] observe new wide image in footer Identifier section
- [x] change Logo Type back to "Square" observe image shrinking to fit space to left of "Website/ Application Name" text (which has also reappeared)

**Code formatting**

✅ 

**Closing issues**

Closes #66 
