### PR TITLE
Hotfix 20220103

### DIFF
--- a/src/aura/uswds404/uswds404.design
+++ b/src/aura/uswds404/uswds404.design
@@ -10,7 +10,8 @@
   <design:attribute
     name="urlPattern"
     label="URL Pattern"
-    description="Enter a typical URL pattern that is used for this site e.g. '/s/my-page/00100000acdEF'"
+    description="Enter a typical URL pattern that is used for this site e.g. 'example.gov/s/my-page/00100000acdEF'"
+    placeholder="example.gov/s/"
   />
   <design:attribute
     name="formName"

--- a/src/aura/uswds404/uswds404Helper.js
+++ b/src/aura/uswds404/uswds404Helper.js
@@ -2,7 +2,7 @@
   getContent: function (value) {
     var content = {
       English: {
-        heading: "Page Note Found",
+        heading: "Page Not Found",
         intro:
           "We’re sorry, we can’t find the page you're looking for. It might have been removed, changed its name, or is otherwise unavailable.",
         instructions:

--- a/src/aura/uswds404/uswds404Helper.js
+++ b/src/aura/uswds404/uswds404Helper.js
@@ -2,7 +2,7 @@
   getContent: function (value) {
     var content = {
       English: {
-        heading: "Page Not Found",
+        heading: "Page not found",
         intro:
           "We’re sorry, we can’t find the page you're looking for. It might have been removed, changed its name, or is otherwise unavailable.",
         instructions:

--- a/src/communityThemeDefinitions/USWDS_Lightning_Community.communityThemeDefinition
+++ b/src/communityThemeDefinitions/USWDS_Lightning_Community.communityThemeDefinition
@@ -45,7 +45,7 @@
     <defaultBrandingSet>USWDS_Lightning_Community</defaultBrandingSet>
     <description>A US Web Design System Theme for Lightning Communities. Contribute at https://github.com/GSA/uswds-sf-lightning-community</description>
     <enableExtendedCleanUpOnDelete>true</enableExtendedCleanUpOnDelete>
-    <masterLabel>USWDS v1.4.0</masterLabel>
+    <masterLabel>USWDS v1.4.2</masterLabel>
     <publisher>U.S. GSA</publisher>
     <themeSetting>
         <themeLayout>USWDS_Lightning_Community_themeLayout_Login</themeLayout>


### PR DESCRIPTION
**Summary**

Addresses a spelling error on the 404 Page component, "Page Note Found" >> "Page not found". Also addresses a missing version update to the Community Theme definition that was overlooked in v1.4.1.

**Test plan (required)**

Text updates will have PR reviewed. Updated #113 to create specific tests to prevent this again.

**Code formatting**

✅ 

