### PR TITLE
#184 updated scratch org def to turn of Lightning Web Security by def…

### DIFF
--- a/config/scratch-def.json
+++ b/config/scratch-def.json
@@ -5,6 +5,11 @@
   "settings": {
     "communitiesSettings": {
       "enableNetworksEnabled": true
+    },
+    "securitySettings": {
+      "sessionSettings": {
+        "lockerServiceNext": false
+      }
     }
   }
 }


### PR DESCRIPTION
…ault. This ensures the Jasmine-based Lightning Testing Service can run.


**Summary**

Addresses #184 

**Test plan (required)**

Created new scratch org with scratchorg definition and verified setting was set to false. 

Can be replicated via:

```
sfdx force:org:create -f config/scratch-def.json -a testscratchorg
sfdx force:org:open -u testscratchorg
```

Navigate to `Setup > Session Security > Lightning Web Security` verify checkbox is unchecked.

**Code formatting**

👍 

**Closing issues**

Closes #184 
